### PR TITLE
fixed build with current Rust version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate rand;
 extern crate siphasher;
 
-use rand::Rng;
+use rand::RngCore;
 use siphasher::sip::SipHasher13;
 use std::hash::{Hash, Hasher};
 


### PR DESCRIPTION
```
error[E0599]: no method named `next_u64` found for type `rand::ThreadRng` in the current scope
  --> src/lib.rs:32:33
   |
32 |         Self::new_with_keys(rng.next_u64(), rng.next_u64())
```